### PR TITLE
Added a Pre-Deployment stub to run scripts before running jekyll

### DIFF
--- a/Content/Hooks/deploy.cmd
+++ b/Content/Hooks/deploy.cmd
@@ -49,13 +49,16 @@ IF NOT DEFINED KUDU_SYNC_CMD (
 )
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+:: Pre deployment stub
+IF DEFINED PRE_DEPLOYMENT_ACTION call "%PRE_DEPLOYMENT_ACTION%"
+IF !ERRORLEVEL! NEQ 0 goto error
+
+::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 :: Build Static Site
-:: ----------
 
 call jekyll build -s "%DEPLOYMENT_SOURCE%" -d "%DEPLOYMENT_TARGET%"
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
-
 :: Post deployment stub
 IF DEFINED POST_DEPLOYMENT_ACTION call "%POST_DEPLOYMENT_ACTION%"
 IF !ERRORLEVEL! NEQ 0 goto error

--- a/README.md
+++ b/README.md
@@ -11,3 +11,7 @@ The Jekyll Site Extension adds support for Jekyll to Azure Web App.
 > Note: This site extension downloads `ruby` and `devkit` so the installation takes longer than the portal timeout, so you may see an error in the portal, however the installation should complete. Be Patient.
 
 That's it! Just hook up your GitHub Account or Push a local Git Repo with your Jekyll site.
+
+You can optionally set an Application-Setting in your Azure Web App to run a script before and / or after running the Jekyll Build-Task:
+ * PRE_DEPLOYMENT_ACTION - Command is called before Jekyll Build-Task
+ * POST_DEPLOYMENT_ACTION - Command is called after Jekyll Build-Task


### PR DESCRIPTION
A jekyll theme like [{ Personal }](https://github.com/PanosSakkos/personal-jekyll-theme) has to run a script before jekyll should generate the static Content sites, in this case "scripts/generate-tags" for example.

Also the Pre- and Post-Deployment-Stub should both be documented, found those only when looking at the deployment-script. :wink:
